### PR TITLE
Fix my regression--put back raw/endraw directives.

### DIFF
--- a/lib/jekyll.py
+++ b/lib/jekyll.py
@@ -206,6 +206,8 @@ def write_topic_messages(
     outfile.write(topic_links)
     outfile.write('\n<head><link href="/style.css" rel="stylesheet"></head>\n')
 
+    outfile.write('\n{% raw %}\n')
+
     for msg in messages:
         msg_html = format_message(
                 site_url,
@@ -219,6 +221,8 @@ def write_topic_messages(
                 )
         outfile.write(msg_html)
         outfile.write('\n\n')
+
+    outfile.write('\n{% endraw %}\n')
 
     outfile.write(date_footer)
     outfile.close()


### PR DESCRIPTION
I guess Liquid looks inside HTML messages for stuff and
can be confused by math symbols and such.