### PR TITLE
Separate stream id and stream name in permalink.

### DIFF
--- a/lib/common.py
+++ b/lib/common.py
@@ -24,7 +24,7 @@ def sanitize_topic(topic_name):
 
 # create a unique sanitized identifier for a stream
 def sanitize_stream(stream_name, stream_id):
-    return str(stream_id) + sanitize(stream_name)
+    return str(stream_id) + '-' + sanitize(stream_name)
 
 def stream_validator(settings):
     if not hasattr(settings, 'included_streams'):

--- a/tests/testCommon.py
+++ b/tests/testCommon.py
@@ -21,7 +21,7 @@ def assert_equal(v1, v2):
 def test_sanitize():
     assert_equal(
         common.sanitize_stream(stream_name='foo bar', stream_id=7),
-        '7foobar'
+        '7-foobar'
         )
 
     # The 87695 below is an adler32 hash of the topic name


### PR DESCRIPTION
Without a separation betweeen stream id and name, stream names
starting with a number cannot be distinguished from stream id.
'-' is used to separate id and name.

Also modified `test_sanitize` to work for the change made.
Closes: #23