### PR TITLE
escape question marks in urls

### DIFF
--- a/lib/url.py
+++ b/lib/url.py
@@ -57,7 +57,7 @@ def archive_message_url(site_url, html_root, sanitized_stream_name, sanitized_to
 # remove non-alnum ascii symbols from string
 def sanitize(s):
     return "".join(filter(lambda x:x.isalnum or x==' ', s.encode('ascii', 'ignore')\
-        .decode('utf-8'))).replace(' ','-')
+        .decode('utf-8'))).replace(' ','-').replace('?','%3F')
 
 # create a unique sanitized identifier for a topic
 def sanitize_topic(topic_name):


### PR DESCRIPTION
The script is generating URLs that are incompatible with GH Pages. See the link "Is there code for X?" at https://leanprover-community.github.io/archive/ , which should point to
https://leanprover-community.github.io/archive/stream/217875-Is-there-code-for-X%3F/index.html

I'm not familiar with the many (good!) changes since my original script, so I'm not confident that this PR is correct or complete. Maybe this bug needs to be fixed in a different place.