### PR TITLE
add option to delete history (closes #38)

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,9 +106,12 @@ jobs:
         zulip_bot_email: ${{ secrets.zulip_bot_email }}
         zulip_bot_key: ${{ secrets.zulip_bot_key }}
         github_personal_access_token: ${{ secrets.github_personal_access_token }}
+        delete_history: true
 ```
 
 The above file tells GitHub to run the `zulip-archive` action every 20 minutes. You can adjust the `cron` key to modify the schedule as you feel appropriate. If you Zulip organization history is very large (not the case for most users) we recommend to increase the cron period from running every 30 minutes to maybe run every 1 hour (eg `'0 * * * *'`). This is is because the initial archive run that fetches the messages for the first time takes a lot of time and we don't want the second cron job to start before finishing the first run is over. After the initial run is over you can shorten the cron job period if necessary.
+
+If you are running frequent updates on a moderately sized Zulip channel, the archive you use to run the action will grow very quickly. We recommend setting the `delete_history` option to `true`. This will overwrite the git history in the repository (but keep all the content). If you are using the repository for more than just the Zulip archive, you may want to set this to `false`, but be warned that the repository size may explode.
 
 ### Step 6 - Verify everything works
 

--- a/action.yml
+++ b/action.yml
@@ -22,3 +22,4 @@ runs:
     - ${{ inputs.zulip_bot_email }}
     - ${{ inputs.zulip_bot_key }}
     - ${{ inputs.github_personal_access_token }}
+    - ${{ inputs.delete_history }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,6 +5,7 @@ zulip_organization_url=$1
 zulip_bot_email=$2
 zulip_bot_api_key=$3
 github_personal_access_token=$4
+delete_history=$5
 
 checked_out_repo_path="$(pwd)"
 html_dir_path=$checked_out_repo_path
@@ -12,6 +13,7 @@ json_dir_path="${checked_out_repo_path}/zulip_json"
 _layouts_path="${checked_out_repo_path}/_layouts"
 img_dir_path="${checked_out_repo_path}/assets/img"
 streams_config_file_path="${checked_out_repo_path}/streams.yaml"
+initial_sha="$(git rev-parse HEAD)"
 
 if [ ! -f $streams_config_file_path ]; then
     echo "Missing streams.yaml file."
@@ -75,14 +77,36 @@ cd ${checked_out_repo_path}
 
 git checkout master
 
+git fetch origin
+
+current_sha="$(git rev-parse origin/master)"
+
+if [[ "$current_sha" != "$initial_sha" ]]
+then 
+  echo "Archive update failed, commits have been added while processing"
+  exit 1 
+fi 
+
+echo "delete history: $delete_history"
+
+if [[ "$delete_history" == "true" ]]
+then 
+    echo "resetting"
+    rm -rf .git 
+    git init 
+fi 
+
+
 git config --global user.email "zulip-archive-bot@users.noreply.github.com"
 git config --global user.name "Archive Bot"
 
 git add -A
 git commit -m "Update archive."
 
-git remote set-url --push origin https://${GITHUB_ACTOR}:${github_personal_access_token}@github.com/${GITHUB_REPOSITORY}
+git remote add origin2 https://${GITHUB_ACTOR}:${github_personal_access_token}@github.com/${GITHUB_REPOSITORY}
 
-git push origin master --force
+git push origin2 master -f
+
+echo "pushed"
 
 echo "Zulip Archive published/updated in ${github_pages_url}"


### PR DESCRIPTION
Using the archive script as a GitHub action is unsustainable right now because of #38. Our archive repository grew from nothing to 5gb in just under a month. Note that since #19, every file gets modified every time the script runs, to update the timestamp, which guarantees enormous diffs. 

This PR adds a config option to overwrite history. If it's set, the archive repository will be reset to exactly one commit every time the script runs. It will not undo changes, just the commit history. 

This is opt-in (the default in the readme is to preserve history) but strongly recommended. At the pace of the Lean Zulip chat, after 6 months of hourly updates, each update would take longer than an hour.

In fact, the push logic before was even more dangerous: if someone added a commit while the action was running, it would overwrite the history and changes made by that commit. This PR changes the behavior to fail if any commits are added while the action is running, regardless of whether the `delete_history` bit is set.