### PR TITLE
create a _config.yml file with a last_updated variable to avoid messy, long diffs

### DIFF
--- a/lib/files.py
+++ b/lib/files.py
@@ -91,8 +91,12 @@ def read_zulip_messages_for_topic(
     f.close()
     return messages
 
-def open_config(md_root):
-    outfile = open_outfile(md_root, Path('_config.yml'), 'w+')
+def open_read_config(md_root):
+    outfile = open_outfile(('..' / Path(md_root)).resolve(), Path('_config.yml'), 'r+')
+    return outfile;
+
+def open_write_config(md_root):
+    outfile = open_outfile(('..' / Path(md_root)).resolve(), Path('_config.yml'), 'w+')
     return outfile;
 
 def open_main_page(md_root):

--- a/lib/files.py
+++ b/lib/files.py
@@ -91,6 +91,10 @@ def read_zulip_messages_for_topic(
     f.close()
     return messages
 
+def open_config(md_root):
+    outfile = open_outfile(md_root, Path('_config.yml'), 'w+')
+    return outfile;
+
 def open_main_page(md_root):
     outfile = open_outfile(md_root, Path('index.md'), 'w+')
     return outfile

--- a/lib/html.py
+++ b/lib/html.py
@@ -11,6 +11,8 @@ strive for pure HTML in our output in the future.
 add helpers/converters as necessary.)
 '''
 
+from .date_helper import format_date1
+
 from .url import (
     sanitize_stream,
     sanitize_topic,

--- a/lib/html.py
+++ b/lib/html.py
@@ -11,8 +11,6 @@ strive for pure HTML in our output in the future.
 add helpers/converters as necessary.)
 '''
 
-from .date_helper import format_date1
-
 from .url import (
     sanitize_stream,
     sanitize_topic,
@@ -104,8 +102,8 @@ def link_to_zulip(
     zulip_link = f'<a href="{post_link}" class="zl">{img_tag}</a>'
     return zulip_link
 
-def last_updated_footer(stream_info):
-    last_updated = format_date1(stream_info['time'])
-    date_footer = f'\n<hr><p>Last updated: {last_updated} UTC</p>'
+def last_updated_footer():
+    # fetch last updated formatted timestamp from _config.yml
+    date_footer = '\n<hr><p>Last updated: {{ site.last_updated }} UTC</p>'
     return date_footer
 

--- a/lib/jekyll.py
+++ b/lib/jekyll.py
@@ -19,6 +19,8 @@ language of choice, this is probably the best place to start.
 from pathlib import Path
 from shutil import copyfile
 
+import yaml
+
 from .date_helper import format_date1
 
 from .url import (
@@ -99,9 +101,16 @@ def build_website(json_root, md_root, site_url, html_root, title, zulip_url, zul
 # `stream_info`: a dict read from the big JSON of streams metadata
 def write_config(md_root, stream_info):
     last_updated = format_date1(stream_info['time'])
-    outfile = open_config(md_root)
-    outfile.write(f'last_updated: {last_updated}\n')
-    outfile.close()
+    config_file = open_read_config(md_root)
+
+    config = yaml.load(config_file, Loader=yaml.FullLoader)
+    config_file.close()
+
+    config['last_updated'] = last_updated
+
+    config_file = open_write_config(md_root)
+    yaml.dump(config, config_file)
+    config_file.close()
 
 # writes the index page listing all streams.
 # `streams`: a dict mapping stream names to stream json objects as described in the header.

--- a/lib/jekyll.py
+++ b/lib/jekyll.py
@@ -19,12 +19,15 @@ language of choice, this is probably the best place to start.
 from pathlib import Path
 from shutil import copyfile
 
+from .date_helper import format_date1
+
 from .url import (
     sanitize_stream,
     sanitize_topic,
     )
 
 from .files import (
+    open_config,
     open_main_page,
     open_stream_topics_page,
     open_topic_messages_page,
@@ -57,7 +60,8 @@ def build_website(json_root, md_root, site_url, html_root, title, zulip_url, zul
     stream_info = read_zulip_stream_info(json_root)
 
     streams = stream_info['streams']
-    date_footer = last_updated_footer(stream_info)
+    date_footer = last_updated_footer()
+    write_config(md_root, stream_info)
     write_main_page(md_root, site_url, html_root, title, streams, date_footer)
     write_css(md_root)
 
@@ -91,6 +95,13 @@ def build_website(json_root, md_root, site_url, html_root, title, zulip_url, zul
                 date_footer,
                 )
 
+# writes the _config.yml file, currently only needed for last_updated
+# `streams`: a dict mapping stream names to stream json objects as described in the header.
+def write_config(md_root, streams):
+    last_updated = format_date1(stream_info['time'])
+    outfile = open_config(md_root)
+    outfile.write(f'last_updated: {last_updated}\n')
+    outfile.close()
 
 # writes the index page listing all streams.
 # `streams`: a dict mapping stream names to stream json objects as described in the header.

--- a/lib/jekyll.py
+++ b/lib/jekyll.py
@@ -96,8 +96,8 @@ def build_website(json_root, md_root, site_url, html_root, title, zulip_url, zul
                 )
 
 # writes the _config.yml file, currently only needed for last_updated
-# `streams`: a dict mapping stream names to stream json objects as described in the header.
-def write_config(md_root, streams):
+# `stream_info`: a dict read from the big JSON of streams metadata
+def write_config(md_root, stream_info):
     last_updated = format_date1(stream_info['time'])
     outfile = open_config(md_root)
     outfile.write(f'last_updated: {last_updated}\n')


### PR DESCRIPTION
Since "Last Updated" is in the footer of every page, diffs from one update to the next are 99% just changes in this line, polluting the diffs with thousands of uninformative lines.
This PR puts the formatted timestamp of the last update in a _config.yml file, [whose variables are exposed to all Jekyll files](https://jekyllrb.com/docs/variables/).
The footer of each page then just reads this variable, therefore doesn't change from an update to the next so git diffs won't be polluted.

⚠️ I don't know how to test it so this is untested.