### PR TITLE
css: Rectify path to make style.css work.

### DIFF
--- a/lib/jekyll.py
+++ b/lib/jekyll.py
@@ -204,7 +204,7 @@ def write_topic_messages(
         )
 
     outfile.write(topic_links)
-    outfile.write('\n<head><link href="/style.css" rel="stylesheet"></head>\n')
+    outfile.write(f'\n<head><link href="{site_url}/style.css" rel="stylesheet"></head>\n')
 
     outfile.write('\n{% raw %}\n')
 


### PR DESCRIPTION
Correctly detects path now, which wasn't the case before and it was throwing 404. I replaced the style.css relative path with an absolute path, as we are defining the base href as the link to zulip chat.
Fixes #36.
