### PR TITLE
[BUGFIX] entrypoint.sh: Make enabling GH Pages work again.

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -37,7 +37,7 @@ auth_header="Authorization: Bearer ${github_personal_access_token}"
 accept_header="Accept: application/vnd.github.switcheroo-preview+json"
 page_api_url="https://api.github.com/repos/${GITHUB_REPOSITORY}/pages"
 # Enable GitHub pages
-curl -H "$auth_header" -H "$accept_header" --data "source=${archive_branch}" "$page_api_url"
+curl -H "$auth_header" -H "$accept_header" --data "{\"source\":{\"branch\":\"${archive_branch}\"}}" "$page_api_url"
 
 print_site_url_code="import sys, json; print(json.load(sys.stdin)['html_url'])"
 github_pages_url_with_trailing_slash=$(curl -H "${auth_header}" $page_api_url | python3 -c "${print_site_url_code}")


### PR DESCRIPTION
GitHub has changed their API. The old method no longer works.