### PR TITLE
fix a typing error: json.load(p, encoding='utf-8') takes no encoding

### DIFF
--- a/lib/files.py
+++ b/lib/files.py
@@ -73,7 +73,7 @@ def read_zulip_stream_info(json_root):
     to other files deeper in the directory structure.
     """
     f = (json_root / Path("stream_index.json")).open("r", encoding="utf-8")
-    stream_info = json.load(f, encoding="utf-8")
+    stream_info = json.load(f)
     f.close()
     return stream_info
 

--- a/lib/populate.py
+++ b/lib/populate.py
@@ -196,7 +196,7 @@ def populate_incremental(
         exit_immediately(error_msg)
 
     f = stream_index.open("r", encoding="utf-8")
-    js = json.load(f, encoding="utf-8")
+    js = json.load(f)
     f.close()
 
     for s in (s for s in streams if is_valid_stream_name(s["name"])):


### PR DESCRIPTION
According to the 'json' documentation, json.load never took an
encoding parameter, json.loads (load string) had one until
3.9. I guess that recently the checks for irrelevant parameters got
stricter, this causes a failure on my Python 3.9 setup:

```
TypeError: __init__() got an unexpected keyword argument 'encoding'
```

fixes #50