### PR TITLE
Don't mark '*' as safe from sanitize

### DIFF
--- a/lib/url.py
+++ b/lib/url.py
@@ -83,7 +83,7 @@ def sanitize(s):
 # create a unique sanitized identifier for a topic
 def sanitize_topic(topic_name):
     return (
-        urllib.parse.quote(topic_name, safe="~()*!.'")
+        urllib.parse.quote(topic_name, safe="~()!.'")
         .replace(".", "%2E")
         .replace("%", ".")
     )


### PR DESCRIPTION
The current behavior does not work on windows because `*` is not allowed in a filename