### PR TITLE
fix: Address GitHub workaround for CVE-2022-24765. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ jobs:
     name: A job to publish zulip-archive in GitHub pages
     steps:
     - name: Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v3
     - name: Run archive
       id: archive
       uses: zulip/zulip-archive@master

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,6 +8,10 @@ github_personal_access_token=$4
 delete_history=$5
 archive_branch=$6
 
+# This is a temporary workaround.
+# See https://github.com/actions/checkout/issues/766
+git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
 checked_out_repo_path="$(pwd)"
 html_dir_path=$checked_out_repo_path
 json_dir_path="${checked_out_repo_path}/zulip_json"


### PR DESCRIPTION
This fixes the problem with the following error message:
```
fatal: unsafe repository ('/github/workspace' is owned by someone else)
To add an exception for this directory, call:

    git config --global --add safe.directory /github/workspace
```

The problem is due to the security fix from the Git security vulnerability
recently announced:
https://github.blog/2022-04-12-git-security-vulnerability-announced/.

Relevant GH issue: https://github.com/actions/checkout/issues/760