### PR TITLE
entrypoint.sh: Remove the statement stating GitHub pages API in preview.

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -37,7 +37,8 @@ pip3 install pyyaml==5.2
 # crudini is not available as an Alpine pkg, so we install via pip.
 pip3 install crudini
 
-# GitHub pages API is in Preview mode. This might break in future.
+# Uses GitHub pages API
+# https://docs.github.com/en/rest/pages
 auth_header="Authorization: Bearer ${github_personal_access_token}"
 accept_header="Accept: application/vnd.github.switcheroo-preview+json"
 page_api_url="https://api.github.com/repos/${GITHUB_REPOSITORY}/pages"


### PR DESCRIPTION
It is no longer in preview mode.
Also adds a link to the official documentation.

Closes https://github.com/zulip/zulip-archive/issues/78