### PR TITLE
Revert "Use a more efficient way to prune history."

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -110,18 +110,19 @@ fi
 
 echo "delete history: $delete_history"
 
+if [[ "$delete_history" == "true" ]]
+then
+    echo "resetting"
+    rm -rf .git
+    git config --global init.defaultBranch "$archive_branch"
+    git init
+fi
+
 git config --global user.email "zulip-archive-bot@users.noreply.github.com"
 git config --global user.name "Archive Bot"
 
 git add -A
-if [[ "$delete_history" == "true" ]]
-then
-	git commit --amend -m "Update archive."
-	# Cleanup loose objects
-	git gc
-else
-	git commit -m "Update archive."
-fi
+git commit -m "Update archive."
 
 git remote add origin2 https://${GITHUB_ACTOR}:${github_token}@github.com/${GITHUB_REPOSITORY}
 


### PR DESCRIPTION
This reverts commit eb19c9fb15791aee1eaa70e9302bd55af5a456dc.

In the light of https://github.com/zulip/zulip-archive/pull/101#issuecomment-1632551877, the actually cause to #100 is due to upstream issue in Curl, which has since been fixed.