### PR TITLE
Avoid bloating previous author's contribution stats

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -116,7 +116,7 @@ git config --global user.name "Archive Bot"
 git add -A
 if [[ "$delete_history" == "true" ]]
 then
-	git commit --amend -m "Update archive."
+	git commit --amend --reset-author -m "Update archive."
 	# Cleanup loose objects
 	git gc
 else


### PR DESCRIPTION
Otherwise GitHub counts each force-push of an amended commit as a contribution by the original author, which may lead to hundreds and thousands of "fake" contributions provided that action typically runs multiple times a day.

This is a #101 fixup (see https://github.com/zulip/zulip-archive/pull/101#issuecomment-1632551877) and an alternative to #105.

I use my fork/branch for [OSMLatvija/zulip-archive](https://github.com/OSMLatvija/zulip-archive) and it seems to work just fine.