### PR TITLE
Migrate from the deprecated and removed APIs

### DIFF
--- a/lib/website.py
+++ b/lib/website.py
@@ -15,9 +15,8 @@ language of choice, this is probably the best place to start.
 """
 
 from pathlib import Path
-from distutils.dir_util import copy_tree
 import html
-from shutil import copyfile
+from shutil import copyfile, copytree
 
 from .url import (
     sanitize_stream,
@@ -114,7 +113,7 @@ def build_website(
     # Copy the entire content of <repo_root>/assets into md_root.
     # We use copy_tree from distutils instead of shutil.copytree so that it
     # doesn't raise an error when assets/ already exists inside the md_root.
-    copy_tree(str(Path(repo_root) / "assets"), str(Path(md_root) / "assets"))
+    copytree(str(Path(repo_root) / "assets"), str(Path(md_root) / "assets"))
 
     # Copy .nojekyll into md_root as well.
     copyfile(str(Path(repo_root) / ".nojekyll"), str(Path(md_root) / ".nojekyll"))

--- a/lib/website.py
+++ b/lib/website.py
@@ -110,10 +110,11 @@ def build_website(
                 page_footer_html,
             )
 
-    # Copy the entire content of <repo_root>/assets into md_root.
-    # We use copy_tree from distutils instead of shutil.copytree so that it
-    # doesn't raise an error when assets/ already exists inside the md_root.
-    copytree(str(Path(repo_root) / "assets"), str(Path(md_root) / "assets"))
+    copytree(
+        str(Path(repo_root) / "assets"),
+        str(Path(md_root) / "assets"),
+        dirs_exist_ok=True,
+    )
 
     # Copy .nojekyll into md_root as well.
     copyfile(str(Path(repo_root) / ".nojekyll"), str(Path(md_root) / ".nojekyll"))


### PR DESCRIPTION
The old API is removed in Py 3.12 and in `entrypoint.sh` we always use the latest Py version.