### PR TITLE
Pin Python version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3-alpine
+FROM python:3.11-alpine
 
 RUN mkdir -p /zulip-archive && apk update && apk add git curl
 


### PR DESCRIPTION
Today zulip-archive GitHub Action started to fail with the following error:
```
Traceback (most recent call last):
  File "/zulip-archive-action/archive.py", line 50, in <module>
    from lib.website import build_website
  File "/zulip-archive-action/lib/website.py", line 18, in <module>
    from distutils.dir_util import copy_tree
ModuleNotFoundError: No module named 'distutils'
```

The reason turned out to be a [release of Python 3.12.0](https://www.python.org/downloads/release/python-3120/) which among other things contains the following change:
> The deprecated `smtpd` and `distutils` modules have been removed (see [PEP 594](https://peps.python.org/pep-0594/) and [PEP 632](https://peps.python.org/pep-0632/). The `setuptools` package continues to provide the `distutils` module.

The fastest fix is to stick to Python 3.11 for now. This will immediately fix failing workflows without the risk of breaking other things. Version pinning is also advised in [Best practices for Dockerfile instructions](https://docs.docker.com/develop/develop-images/instructions/):
> Version pinning forces the build to retrieve a particular version regardless of what’s in the cache. This technique can also reduce failures due to unanticipated changes in required packages.

For a more complete solutions, that makes zulip-archive compatible with Python 3.12 please see #109.

However, I would advise to keep the version pinning anyway, because it makes Docker builds reproducible. If Python version had been pinned earlier, there would not have been any failures due to 3.12.0 release today.